### PR TITLE
Expand dependencies to accept serverless@3.0 and up

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {},
   "peerDependencies": {
-    "serverless": "2.x"
+    "serverless": "2.x || 3.x"
   },
   "engines": {
     "node": ">=10.0"


### PR DESCRIPTION
Updating the peer dependencies of this plugin to allow use of `serverless` versions 3.0 and higher.